### PR TITLE
Ability to specify custom Circle Endpoint added

### DIFF
--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -26,6 +26,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_ORGANIZATION", nil),
 				Description: "The CircleCI organization.",
 			},
+			"url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_URL", "https://circleci.com/api/v1.1"),
+				Description: "The URL of the Circle CI API.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"circleci_environment_variable": resourceCircleCIEnvironmentVariable(),
@@ -38,5 +44,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	token := d.Get("api_token").(string)
 	vcsType := d.Get("vcs_type").(string)
 	organization := d.Get("organization").(string)
-	return NewConfig(token, vcsType, organization), nil
+	url := d.Get("url").(string)
+	return NewConfig(token, vcsType, organization, url)
 }

--- a/circleci/provider_client.go
+++ b/circleci/provider_client.go
@@ -1,6 +1,8 @@
 package circleci
 
 import (
+	"net/url"
+
 	circleciapi "github.com/jszwedko/go-circleci"
 )
 
@@ -12,14 +14,20 @@ type ProviderClient struct {
 }
 
 // NewConfig initialize circleci API client and returns a new config object
-func NewConfig(token, vscType, organization string) *ProviderClient {
+func NewConfig(token, vscType, organization, baseURL string) (*ProviderClient, error) {
+	parsedUrl, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ProviderClient{
 		client: &circleciapi.Client{
-			Token: token,
+			BaseURL: parsedUrl,
+			Token:   token,
 		},
 		vcsType:      vscType,
 		organization: organization,
-	}
+	}, nil
 }
 
 // GetEnvVar get the environment variable with given name


### PR DESCRIPTION
While attempting to use this provider with an internally hosted version of CircleCI, I noticed that I was unable to set a custom URL endpoint for CircleCI. This adds the ability to set a custom endpoint via environment variable or explicitly on the provider definition