### PR TITLE
Organisation added to env resource

### DIFF
--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -20,6 +20,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_VCS_TYPE", "github"),
 				Description: "The VCS type for the organization.",
 			},
+			"organization": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_ORGANIZATION", nil),
+				Description: "The CircleCI organization.",
+			},
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -38,5 +44,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	token := d.Get("api_token").(string)
 	vcsType := d.Get("vcs_type").(string)
 	url := d.Get("url").(string)
+
+	if organization, ok := d.GetOk("organization"); ok {
+		return NewOrganizationConfig(token, vcsType, organization.(string), url)
+	}
+
 	return NewConfig(token, vcsType, url)
 }

--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -20,12 +20,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_VCS_TYPE", "github"),
 				Description: "The VCS type for the organization.",
 			},
-			"organization": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_ORGANIZATION", nil),
-				Description: "The CircleCI organization.",
-			},
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -43,7 +37,6 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	token := d.Get("api_token").(string)
 	vcsType := d.Get("vcs_type").(string)
-	organization := d.Get("organization").(string)
 	url := d.Get("url").(string)
-	return NewConfig(token, vcsType, organization, url)
+	return NewConfig(token, vcsType, url)
 }

--- a/circleci/provider_client.go
+++ b/circleci/provider_client.go
@@ -11,7 +11,7 @@ import (
 type ProviderClient struct {
 	client       *circleciapi.Client
 	vcsType      string
-	organization *string
+	organization string
 }
 
 // NewConfig initialize circleci API client and returns a new config object
@@ -42,30 +42,30 @@ func NewOrganizationConfig(token, vscType, organization, baseURL string) (*Provi
 			BaseURL: parsedUrl,
 			Token:   token,
 		},
-		organization: &organization,
+		organization: organization,
 		vcsType:      vscType,
 	}, nil
 }
 
 // GetEnvVar get the environment variable with given name
 // It returns an empty structure if no environment variable exists with that name
-func (pv *ProviderClient) GetEnvVar(organization *string, projectName, envVarName string) (*circleciapi.EnvVar, error) {
+func (pv *ProviderClient) GetEnvVar(organization string, projectName, envVarName string) (*circleciapi.EnvVar, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return nil, err
 	}
 
-	return pv.client.GetEnvVar(pv.vcsType, *org, projectName, envVarName)
+	return pv.client.GetEnvVar(pv.vcsType, org, projectName, envVarName)
 }
 
 // EnvVarExists check if environment variable exists with given name
-func (pv *ProviderClient) EnvVarExists(organization *string, projectName, envVarName string) (bool, error) {
+func (pv *ProviderClient) EnvVarExists(organization string, projectName, envVarName string) (bool, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
 
-	envVar, err := pv.client.GetEnvVar(pv.vcsType, *org, projectName, envVarName)
+	envVar, err := pv.client.GetEnvVar(pv.vcsType, org, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
@@ -73,31 +73,31 @@ func (pv *ProviderClient) EnvVarExists(organization *string, projectName, envVar
 }
 
 // AddEnvVar create an environment variable with given name and value
-func (pv *ProviderClient) AddEnvVar(organization *string, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
+func (pv *ProviderClient) AddEnvVar(organization string, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return nil, err
 	}
 
-	return pv.client.AddEnvVar(pv.vcsType, *org, projectName, envVarName, envVarValue)
+	return pv.client.AddEnvVar(pv.vcsType, org, projectName, envVarName, envVarValue)
 }
 
 // DeleteEnvVar delete the environment variable with given name
-func (pv *ProviderClient) DeleteEnvVar(organization *string, projectName, envVarName string) error {
+func (pv *ProviderClient) DeleteEnvVar(organization string, projectName, envVarName string) error {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return err
 	}
 
-	return pv.client.DeleteEnvVar(pv.vcsType, *org, projectName, envVarName)
+	return pv.client.DeleteEnvVar(pv.vcsType, org, projectName, envVarName)
 }
 
-func (pv *ProviderClient) validateOrganization(organization *string, projectName, envVarName string) (*string, error) {
-	if organization == nil && pv.organization == nil {
-		return nil, fmt.Errorf("organization has not been set for environment variable %s in project %s", projectName, envVarName)
+func (pv *ProviderClient) validateOrganization(organization string, projectName, envVarName string) (string, error) {
+	if organization == "" && pv.organization == "" {
+		return "", fmt.Errorf("organization has not been set for environment variable %s in project %s", projectName, envVarName)
 	}
 
-	if organization != nil {
+	if organization != "" {
 		return organization, nil
 	}
 

--- a/circleci/provider_client.go
+++ b/circleci/provider_client.go
@@ -8,13 +8,12 @@ import (
 
 // ProviderClient is a thin commodity wrapper on top of circleciapi
 type ProviderClient struct {
-	client       *circleciapi.Client
-	vcsType      string
-	organization string
+	client  *circleciapi.Client
+	vcsType string
 }
 
 // NewConfig initialize circleci API client and returns a new config object
-func NewConfig(token, vscType, organization, baseURL string) (*ProviderClient, error) {
+func NewConfig(token, vscType, baseURL string) (*ProviderClient, error) {
 	parsedUrl, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -25,20 +24,19 @@ func NewConfig(token, vscType, organization, baseURL string) (*ProviderClient, e
 			BaseURL: parsedUrl,
 			Token:   token,
 		},
-		vcsType:      vscType,
-		organization: organization,
+		vcsType: vscType,
 	}, nil
 }
 
 // GetEnvVar get the environment variable with given name
 // It returns an empty structure if no environment variable exists with that name
-func (pv *ProviderClient) GetEnvVar(projectName, envVarName string) (*circleciapi.EnvVar, error) {
-	return pv.client.GetEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) GetEnvVar(organization, projectName, envVarName string) (*circleciapi.EnvVar, error) {
+	return pv.client.GetEnvVar(pv.vcsType, organization, projectName, envVarName)
 }
 
 // EnvVarExists check if environment variable exists with given name
-func (pv *ProviderClient) EnvVarExists(projectName, envVarName string) (bool, error) {
-	envVar, err := pv.client.GetEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) EnvVarExists(organization, projectName, envVarName string) (bool, error) {
+	envVar, err := pv.client.GetEnvVar(pv.vcsType, organization, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
@@ -46,11 +44,11 @@ func (pv *ProviderClient) EnvVarExists(projectName, envVarName string) (bool, er
 }
 
 // AddEnvVar create an environment variable with given name and value
-func (pv *ProviderClient) AddEnvVar(projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
-	return pv.client.AddEnvVar(pv.vcsType, pv.organization, projectName, envVarName, envVarValue)
+func (pv *ProviderClient) AddEnvVar(organization, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
+	return pv.client.AddEnvVar(pv.vcsType, organization, projectName, envVarName, envVarValue)
 }
 
 // DeleteEnvVar delete the environment variable with given name
-func (pv *ProviderClient) DeleteEnvVar(projectName, envVarName string) error {
-	return pv.client.DeleteEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) DeleteEnvVar(organization, projectName, envVarName string) error {
+	return pv.client.DeleteEnvVar(pv.vcsType, organization, projectName, envVarName)
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -11,14 +11,29 @@ import (
 var testProvider *schema.Provider
 var testProviders map[string]terraform.ResourceProvider
 
+var resourceOrgTestProvider *schema.Provider
+var resourceOrgTestProviders map[string]terraform.ResourceProvider
+
 func init() {
+	resourceOrgTestProvider = Provider().(*schema.Provider)
+	resourceOrgTestProviders = map[string]terraform.ResourceProvider{
+		"circleci": resourceOrgTestProvider,
+	}
+
 	testProvider = Provider().(*schema.Provider)
+	testProvider.Schema["organization"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("TEST_CIRCLECI_ORGANIZATION", nil),
+		Description: "The CircleCI organization.",
+	}
 	testProviders = map[string]terraform.ResourceProvider{
 		"circleci": testProvider,
 	}
 }
 
 func testPreCheck(t *testing.T) {
+
 	if v := os.Getenv("CIRCLECI_TOKEN"); v == "" {
 		t.Fatal("CIRCLECI_TOKEN must be set for acceptance tests")
 	}
@@ -29,5 +44,9 @@ func testPreCheck(t *testing.T) {
 
 	if v := os.Getenv("CIRCLECI_PROJECT"); v == "" {
 		t.Fatal("CIRCLECI_PROJECT must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v != "" {
+		t.Fatal("For testing purposes do not set CIRCLECI_ORGANIZATION instead set TEST_CIRCLECI_ORGANIZATION for acceptance tests")
 	}
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -49,4 +49,8 @@ func testPreCheck(t *testing.T) {
 	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v != "" {
 		t.Fatal("For testing purposes do not set CIRCLECI_ORGANIZATION instead set TEST_CIRCLECI_ORGANIZATION for acceptance tests")
 	}
+
+	if v := os.Getenv("TEST_CIRCLECI_ORGANIZATION"); v == "" {
+		t.Fatal("TEST_CIRCLECI_ORGANIZATION must be set for acceptance tests")
+	}
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-var testProvider *schema.Provider
-var testProviders map[string]terraform.ResourceProvider
+var providerOrgTestProvider *schema.Provider
+var providerOrgTestProviders map[string]terraform.ResourceProvider
 
 var resourceOrgTestProvider *schema.Provider
 var resourceOrgTestProviders map[string]terraform.ResourceProvider
@@ -20,15 +20,15 @@ func init() {
 		"circleci": resourceOrgTestProvider,
 	}
 
-	testProvider = Provider().(*schema.Provider)
-	testProvider.Schema["organization"] = &schema.Schema{
+	providerOrgTestProvider = Provider().(*schema.Provider)
+	providerOrgTestProvider.Schema["organization"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("TEST_CIRCLECI_ORGANIZATION", nil),
 		Description: "The CircleCI organization.",
 	}
-	testProviders = map[string]terraform.ResourceProvider{
-		"circleci": testProvider,
+	providerOrgTestProviders = map[string]terraform.ResourceProvider{
+		"circleci": providerOrgTestProvider,
 	}
 }
 

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -27,10 +27,6 @@ func testPreCheck(t *testing.T) {
 		t.Fatal("CIRCLECI_VCS_TYPE must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v == "" {
-		t.Fatal("CIRCLECI_ORGANIZATION must be set for acceptance tests")
-	}
-
 	if v := os.Getenv("CIRCLECI_PROJECT"); v == "" {
 		t.Fatal("CIRCLECI_PROJECT must be set for acceptance tests")
 	}

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -30,7 +30,7 @@ func resourceCircleCIEnvironmentVariable() *schema.Resource {
 			"organization": {
 				Description: "The CircleCI organization.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 			},
 			"project": {
@@ -83,7 +83,7 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
@@ -109,7 +109,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -130,7 +130,7 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -147,7 +147,7 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -157,4 +157,14 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	}
 
 	return bool(envVar.Value != ""), nil
+}
+
+func getOrganization(d *schema.ResourceData) *string {
+	organization, ok := d.GetOk("organization")
+	if ok {
+		org := organization.(string)
+		return &org
+	}
+
+	return nil
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -159,11 +159,11 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	return bool(envVar.Value != ""), nil
 }
 
-func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) *string {
+func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) string {
 	organization, ok := d.GetOk("organization")
 	if ok {
 		org := organization.(string)
-		return &org
+		return org
 	}
 
 	return providerClient.organization

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -83,7 +83,7 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
@@ -109,7 +109,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -130,7 +130,7 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -147,7 +147,7 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -159,12 +159,12 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	return bool(envVar.Value != ""), nil
 }
 
-func getOrganization(d *schema.ResourceData) *string {
+func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) *string {
 	organization, ok := d.GetOk("organization")
 	if ok {
 		org := organization.(string)
 		return &org
 	}
 
-	return nil
+	return providerClient.organization
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -27,6 +27,12 @@ func resourceCircleCIEnvironmentVariable() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"organization": {
+				Description: "The CircleCI organization.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
 			"project": {
 				Description: "The name of the CircleCI project to create the variable in",
 				Type:        schema.TypeString,
@@ -77,11 +83,12 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
 
-	exists, err := providerClient.EnvVarExists(projectName, envName)
+	exists, err := providerClient.EnvVarExists(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -90,7 +97,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 		return fmt.Errorf("environment variable '%s' already exists for project '%s'", envName, projectName)
 	}
 
-	if _, err := providerClient.AddEnvVar(projectName, envName, envValue); err != nil {
+	if _, err := providerClient.AddEnvVar(organization, projectName, envName, envValue); err != nil {
 		return err
 	}
 
@@ -102,10 +109,11 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	envVar, err := providerClient.GetEnvVar(projectName, envName)
+	envVar, err := providerClient.GetEnvVar(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -122,10 +130,11 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	err := providerClient.DeleteEnvVar(projectName, envName)
+	err := providerClient.DeleteEnvVar(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -138,10 +147,11 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	envVar, err := providerClient.GetEnvVar(projectName, envName)
+	envVar, err := providerClient.GetEnvVar(organization, projectName, envName)
 	if err != nil {
 		return false, err
 	}

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -20,9 +20,8 @@ func TestCircleCIEnvironmentVariableOrganizationNotSet(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
-		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
-		IsUnitTest:   true,
+		Providers:  resourceOrgTestProviders,
+		IsUnitTest: true,
 		Steps: []resource.TestStep{
 			{
 				Config:      testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test"),
@@ -67,7 +66,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
-	organization := "ORG_" + acctest.RandString(8)
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 	envName := "TEST_" + acctest.RandString(8)
 
 	resourceName := "circleci_environment_variable." + envName
@@ -76,7 +75,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
+		Providers:    resourceOrgTestProviders,
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,7 +100,6 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
-	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
 
@@ -115,7 +113,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, envValue),
+				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -123,7 +121,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 				),
 			},
 			{
-				Config:      testCircleCIEnvironmentVariableConfigIdentical(organization, project, envName, envValue),
+				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
 			},
 		},
@@ -171,19 +169,17 @@ resource "circleci_environment_variable" "%[2]s" {
 }`, project, name, value, organization)
 }
 
-func testCircleCIEnvironmentVariableConfigIdentical(organization, project, name, value string) string {
+func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  organization = "%[4]s"
   project 	   = "%[1]s"
   name    	   = "%[2]s"
   value   	   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  organization = "%[4]s"
   project 	   = "%[1]s"
   name    	   = "%[2]s"
   value   	   = "%[3]s"
-}`, project, name, value, organization)
+}`, project, name, value)
 }

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -146,10 +146,10 @@ func testCircleCIEnvironmentVariableCheckDestroy(providerClient *ProviderClient,
 
 		organization := rs.Primary.Attributes["organization"]
 		if organization == "" {
-			organization = *providerClient.organization
+			organization = providerClient.organization
 		}
 
-		envVar, err := providerClient.GetEnvVar(&organization, rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
+		envVar, err := providerClient.GetEnvVar(organization, rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
 		if err != nil {
 			return err
 		}

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 
 	resourceName := "circleci_environment_variable." + envName
@@ -26,7 +27,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, "value-for-the-test"),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -34,7 +35,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, "value-for-the-test-again"),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -47,6 +48,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
 
@@ -60,7 +62,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, envValue),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -68,7 +70,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 				),
 			},
 			{
-				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
+				Config:      testCircleCIEnvironmentVariableConfigIdentical(organization, project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
 			},
 		},
@@ -83,7 +85,7 @@ func testCircleCIEnvironmentVariableCheckDestroy(s *terraform.State) error {
 			continue
 		}
 
-		envVar, err := providerClient.GetEnvVar(rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
+		envVar, err := providerClient.GetEnvVar(rs.Primary.Attributes["organization"], rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
 		if err != nil {
 			return err
 		}
@@ -96,26 +98,29 @@ func testCircleCIEnvironmentVariableCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCircleCIEnvironmentVariableConfig(project, name, value string) string {
+func testCircleCIEnvironmentVariableConfig(organization, project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
-}`, project, name, value)
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
+}`, project, name, value, organization)
 }
 
-func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
+func testCircleCIEnvironmentVariableConfigIdentical(organization, project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
-}`, project, name, value)
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
+}`, project, name, value, organization)
 }

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -41,7 +41,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
+		Providers:    providerOrgTestProviders,
 		CheckDestroy: testCircleCIEnvironmentVariableProviderOrgCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -106,7 +106,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	resourceName := "circleci_environment_variable." + envName
 
 	resource.Test(t, resource.TestCase{
-		Providers: testProviders,
+		Providers: providerOrgTestProviders,
 		PreCheck: func() {
 			testPreCheck(t)
 		},
@@ -134,7 +134,7 @@ func testCircleCIEnvironmentVariableResourceOrgCheckDestroy(s *terraform.State) 
 }
 
 func testCircleCIEnvironmentVariableProviderOrgCheckDestroy(s *terraform.State) error {
-	providerClient := testProvider.Meta().(*ProviderClient)
+	providerClient := providerOrgTestProvider.Meta().(*ProviderClient)
 	return testCircleCIEnvironmentVariableCheckDestroy(providerClient, s)
 }
 

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -165,9 +165,9 @@ func testCircleCIEnvironmentVariableCheckDestroy(providerClient *ProviderClient,
 func testCircleCIEnvironmentVariableConfigProviderOrg(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }`, project, name, value)
 }
 
@@ -184,14 +184,14 @@ resource "circleci_environment_variable" "%[2]s" {
 func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }`, project, name, value)
 }


### PR DESCRIPTION
Right now the provider requires you to add the organisation at the provider declaration level, for example 
```hcl
provider "circleci" {
  organization = "foo"
}
```

This is fine when you are managing repos in one organisation. However there are times, for example when using private CircleCI, when you want to manage multiple organisations at once. The current set up does not allow for this easily, especially when you can't dynamically create and reference providers. This use case is particularly important when users can specify Circle projects via some user variable.

The change here move the organisation declaration down to the resource level allowing for a dynamic setting of it, as well as the project name.

```hcl
resource "circleci_environment_variable" "foo" {
  organization = "bar"
  project      = "baz"
  name         = "password"
  value        = "super secret password"
}
```