### PR TITLE
Improved import functionality

### DIFF
--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -103,7 +103,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 	}
 
 	vars := []string{
-		*organization,
+		organization,
 		projectName,
 		envName,
 	}
@@ -191,20 +191,19 @@ func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) str
 }
 
 func getEnvironmentVariableId(d *schema.ResourceData) error {
-	parts := parseEnvironmentVariableId(d.Id())
+	organization, projectName, envName := parseEnvironmentVariableId(d.Id())
 	// Validate that he have values for all the ID segments. This should be at least 3
-	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+	if organization == "" || projectName == "" || envName == "" {
 		return fmt.Errorf("error calculating circle_ci_environment_variable. Please make sure the ID is in the form ORGANIZATION.PROJECTNAME.VARNAME (i.e. foo.bar.my_var)")
 	}
 
-	_ = d.Set("organization", parts[0])
-	_ = d.Set("project", parts[1])
-	_ = d.Set("name", parts[2])
+	_ = d.Set("organization", organization)
+	_ = d.Set("project", projectName)
+	_ = d.Set("name", envName)
 	return nil
 }
 
-func parseEnvironmentVariableId(id string) [3]string {
-	var organization, projectName, envName string
+func parseEnvironmentVariableId(id string) (organization, projectName, envName string) {
 	parts := strings.Split(id, ".")
 
 	if len(parts) >= 3 {
@@ -213,5 +212,5 @@ func parseEnvironmentVariableId(id string) [3]string {
 		envName = parts[len(parts)-1]
 	}
 
-	return [3]string{organization, projectName, envName}
+	return organization, projectName, envName
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -183,7 +183,7 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 
 	// If we don't have a project name we're doing an import. Parse it from the ID.
 	if _, ok := d.GetOk("name"); !ok {
-		if err := getEnvironmentVariableId(d); err != nil {
+		if err := setOrgProjectNameFromEnvironmentVariableId(d); err != nil {
 			return err
 		}
 	}
@@ -228,7 +228,7 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 
 	// If we don't have a project name we're doing an import. Parse it from the ID.
 	if _, ok := d.GetOk("name"); !ok {
-		if err := getEnvironmentVariableId(d); err != nil {
+		if err := setOrgProjectNameFromEnvironmentVariableId(d); err != nil {
 			return false, err
 		}
 	}
@@ -255,7 +255,7 @@ func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) str
 	return providerClient.organization
 }
 
-func getEnvironmentVariableId(d *schema.ResourceData) error {
+func setOrgProjectNameFromEnvironmentVariableId(d *schema.ResourceData) error {
 	organization, projectName, envName := parseEnvironmentVariableId(d.Id())
 	// Validate that he have values for all the ID segments. This should be at least 3
 	if organization == "" || projectName == "" || envName == "" {

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -197,9 +197,9 @@ func getEnvironmentVariableId(d *schema.ResourceData) error {
 		return fmt.Errorf("error calculating circle_ci_environment_variable. Please make sure the ID is in the form ORGANIZATION.PROJECTNAME.VARNAME (i.e. foo.bar.my_var)")
 	}
 
-	d.Set("organization", parts[0])
-	d.Set("project", parts[1])
-	d.Set("name", parts[2])
+	_ = d.Set("organization", parts[0])
+	_ = d.Set("project", parts[1])
+	_ = d.Set("name", parts[2])
 	return nil
 }
 
@@ -207,10 +207,10 @@ func parseEnvironmentVariableId(id string) [3]string {
 	var organization, projectName, envName string
 	parts := strings.Split(id, ".")
 
-	if len(parts) == 3 {
+	if len(parts) >= 3 {
 		organization = parts[0]
-		projectName = parts[1]
-		envName = parts[2]
+		projectName = strings.Join(parts[1:len(parts)-1], ".")
+		envName = parts[len(parts)-1]
 	}
 
 	return [3]string{organization, projectName, envName}

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -273,9 +272,7 @@ func TestCircleCIEnvironmentVariableResourceOrgStateUpgradeV0(t *testing.T) {
 	}
 
 	expected := testCircleCIEnvironmentVariableResourceOrgStateDataV1(organization, project, envName)
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
-	}
+	assert.Equal(t, expected, actual)
 }
 
 func TestCircleCIEnvironmentVariableProviderOrgStateUpgradeV0(t *testing.T) {
@@ -284,15 +281,13 @@ func TestCircleCIEnvironmentVariableProviderOrgStateUpgradeV0(t *testing.T) {
 	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 	providerClient, _ := NewOrganizationConfig("foo", os.Getenv("CIRCLECI_VCS_TYPE"), os.Getenv("TEST_CIRCLECI_ORGANIZATION"), "http://example.com")
 
-	actual, err := resourceCircleCIEnvironmentVariableUpgradeV0(testCircleCIEnvironmentVariableNoOrgStateDataProviderOrgV1(organization, project, envName), providerClient)
+	actual, err := resourceCircleCIEnvironmentVariableUpgradeV0(testCircleCIEnvironmentVariableNoOrgStateDataProviderOrgV0(project, envName), providerClient)
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}
 
 	expected := testCircleCIEnvironmentVariableNoOrgStateDataProviderOrgV1(organization, project, envName)
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
-	}
+	assert.Equal(t, expected, actual)
 }
 
 func testCircleCIEnvironmentVariableResourceOrgCheckDestroy(s *terraform.State) error {

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -3,6 +3,7 @@ package circleci
 import (
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"regexp"
 	"testing"
@@ -201,6 +202,27 @@ func TestCircleCIEnvironmentVariableImportResourceOrg(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestParseEnvironmentVariableId(t *testing.T) {
+	organization := acctest.RandString(8)
+	envName := acctest.RandString(8)
+	projectNames := []string{
+		"TEST_" + acctest.RandString(8),
+		"TEST-" + acctest.RandString(8),
+		"TEST." + acctest.RandString(8),
+		"TEST_" + acctest.RandString(8) + "." + acctest.RandString(8),
+		"TEST-" + acctest.RandString(8) + "." + acctest.RandString(8),
+		"TEST." + acctest.RandString(8) + "." + acctest.RandString(8),
+	}
+
+	for _, name := range projectNames {
+		expectedId := organization + "." + name + "." + envName
+		actualOrganization, actualProjectName, actualEnvName := parseEnvironmentVariableId(expectedId)
+		assert.Equal(t, organization, actualOrganization)
+		assert.Equal(t, name, actualProjectName)
+		assert.Equal(t, envName, actualEnvName)
+	}
 }
 
 func testCircleCIEnvironmentVariableResourceOrgCheckDestroy(s *terraform.State) error {

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -34,8 +34,8 @@ func TestCircleCIEnvironmentVariableOrganizationNotSet(t *testing.T) {
 func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
 	envName := "TEST_" + acctest.RandString(8)
-
 	resourceName := "circleci_environment_variable." + envName
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -47,6 +47,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
@@ -55,6 +56,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test-again")),
@@ -81,6 +83,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
@@ -89,6 +92,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test-again")),
@@ -102,6 +106,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 
 	resourceName := "circleci_environment_variable." + envName
 
@@ -115,6 +120,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString(envValue)),
@@ -123,6 +129,75 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 			{
 				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
+			},
+		},
+	})
+}
+
+func TestCircleCIEnvironmentVariableImportProviderOrg(t *testing.T) {
+	project := os.Getenv("CIRCLECI_PROJECT")
+	envName := "TEST_" + acctest.RandString(8)
+	resourceName := "circleci_environment_variable." + envName
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testPreCheck(t)
+		},
+		Providers:    providerOrgTestProviders,
+		CheckDestroy: testCircleCIEnvironmentVariableProviderOrgCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "name", envName),
+					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("circleci_environment_variable.%s", envName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
+			},
+		},
+	})
+}
+
+func TestCircleCIEnvironmentVariableImportResourceOrg(t *testing.T) {
+	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
+	envName := "TEST_" + acctest.RandString(8)
+
+	resourceName := "circleci_environment_variable." + envName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testPreCheck(t)
+		},
+		Providers:    resourceOrgTestProviders,
+		CheckDestroy: testCircleCIEnvironmentVariableResourceOrgCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "name", envName),
+					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("circleci_environment_variable.%s", envName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/jszwedko/go-circleci v0.2.0
+	github.com/stretchr/testify v1.3.0
 )
 
 replace github.com/jszwedko/go-circleci v0.2.0 => github.com/tgermain/go-circleci v0.0.0-20181207123242-bfc5b3445bba


### PR DESCRIPTION
Importing of environment variables failed due to the nature of the IDs not being globally unique to a state. This allows for multiple environment variables of the same name to be used for different circle projects and orgs

Requires #26 