### PR TITLE
Remove existance check

### DIFF
--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -20,6 +20,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_VCS_TYPE", "github"),
 				Description: "The VCS type for the organization.",
 			},
+			"organization": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_ORGANIZATION", nil),
+				Description: "The CircleCI organization.",
+			},
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -38,5 +44,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	token := d.Get("api_token").(string)
 	vcsType := d.Get("vcs_type").(string)
 	url := d.Get("url").(string)
+
+	if organization, ok := d.GetOk("organization"); ok {
+		return NewOrganizationConfig(token, vcsType, organization.(string), url)
+	}
+
 	return NewConfig(token, vcsType, url)
 }

--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -20,12 +20,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_VCS_TYPE", "github"),
 				Description: "The VCS type for the organization.",
 			},
-			"organization": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CIRCLECI_ORGANIZATION", nil),
-				Description: "The CircleCI organization.",
-			},
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -43,7 +37,6 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	token := d.Get("api_token").(string)
 	vcsType := d.Get("vcs_type").(string)
-	organization := d.Get("organization").(string)
 	url := d.Get("url").(string)
-	return NewConfig(token, vcsType, organization, url)
+	return NewConfig(token, vcsType, url)
 }

--- a/circleci/provider_client.go
+++ b/circleci/provider_client.go
@@ -11,7 +11,7 @@ import (
 type ProviderClient struct {
 	client       *circleciapi.Client
 	vcsType      string
-	organization *string
+	organization string
 }
 
 // NewConfig initialize circleci API client and returns a new config object
@@ -42,30 +42,30 @@ func NewOrganizationConfig(token, vscType, organization, baseURL string) (*Provi
 			BaseURL: parsedUrl,
 			Token:   token,
 		},
-		organization: &organization,
+		organization: organization,
 		vcsType:      vscType,
 	}, nil
 }
 
 // GetEnvVar get the environment variable with given name
 // It returns an empty structure if no environment variable exists with that name
-func (pv *ProviderClient) GetEnvVar(organization *string, projectName, envVarName string) (*circleciapi.EnvVar, error) {
+func (pv *ProviderClient) GetEnvVar(organization string, projectName, envVarName string) (*circleciapi.EnvVar, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return nil, err
 	}
 
-	return pv.client.GetEnvVar(pv.vcsType, *org, projectName, envVarName)
+	return pv.client.GetEnvVar(pv.vcsType, org, projectName, envVarName)
 }
 
 // EnvVarExists check if environment variable exists with given name
-func (pv *ProviderClient) EnvVarExists(organization *string, projectName, envVarName string) (bool, error) {
+func (pv *ProviderClient) EnvVarExists(organization string, projectName, envVarName string) (bool, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
 
-	envVar, err := pv.client.GetEnvVar(pv.vcsType, *org, projectName, envVarName)
+	envVar, err := pv.client.GetEnvVar(pv.vcsType, org, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
@@ -73,31 +73,31 @@ func (pv *ProviderClient) EnvVarExists(organization *string, projectName, envVar
 }
 
 // AddEnvVar create an environment variable with given name and value
-func (pv *ProviderClient) AddEnvVar(organization *string, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
+func (pv *ProviderClient) AddEnvVar(organization string, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return nil, err
 	}
 
-	return pv.client.AddEnvVar(pv.vcsType, *org, projectName, envVarName, envVarValue)
+	return pv.client.AddEnvVar(pv.vcsType, org, projectName, envVarName, envVarValue)
 }
 
 // DeleteEnvVar delete the environment variable with given name
-func (pv *ProviderClient) DeleteEnvVar(organization *string, projectName, envVarName string) error {
+func (pv *ProviderClient) DeleteEnvVar(organization string, projectName, envVarName string) error {
 	org, err := pv.validateOrganization(organization, projectName, envVarName)
 	if err != nil {
 		return err
 	}
 
-	return pv.client.DeleteEnvVar(pv.vcsType, *org, projectName, envVarName)
+	return pv.client.DeleteEnvVar(pv.vcsType, org, projectName, envVarName)
 }
 
-func (pv *ProviderClient) validateOrganization(organization *string, projectName, envVarName string) (*string, error) {
-	if organization == nil && pv.organization == nil {
-		return nil, fmt.Errorf("organization has not been set for environment variable %s in project %s", projectName, envVarName)
+func (pv *ProviderClient) validateOrganization(organization string, projectName, envVarName string) (string, error) {
+	if organization == "" && pv.organization == "" {
+		return "", fmt.Errorf("organization has not been set for environment variable %s in project %s", projectName, envVarName)
 	}
 
-	if organization != nil {
+	if organization != "" {
 		return organization, nil
 	}
 

--- a/circleci/provider_client.go
+++ b/circleci/provider_client.go
@@ -8,13 +8,12 @@ import (
 
 // ProviderClient is a thin commodity wrapper on top of circleciapi
 type ProviderClient struct {
-	client       *circleciapi.Client
-	vcsType      string
-	organization string
+	client  *circleciapi.Client
+	vcsType string
 }
 
 // NewConfig initialize circleci API client and returns a new config object
-func NewConfig(token, vscType, organization, baseURL string) (*ProviderClient, error) {
+func NewConfig(token, vscType, baseURL string) (*ProviderClient, error) {
 	parsedUrl, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -25,20 +24,19 @@ func NewConfig(token, vscType, organization, baseURL string) (*ProviderClient, e
 			BaseURL: parsedUrl,
 			Token:   token,
 		},
-		vcsType:      vscType,
-		organization: organization,
+		vcsType: vscType,
 	}, nil
 }
 
 // GetEnvVar get the environment variable with given name
 // It returns an empty structure if no environment variable exists with that name
-func (pv *ProviderClient) GetEnvVar(projectName, envVarName string) (*circleciapi.EnvVar, error) {
-	return pv.client.GetEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) GetEnvVar(organization, projectName, envVarName string) (*circleciapi.EnvVar, error) {
+	return pv.client.GetEnvVar(pv.vcsType, organization, projectName, envVarName)
 }
 
 // EnvVarExists check if environment variable exists with given name
-func (pv *ProviderClient) EnvVarExists(projectName, envVarName string) (bool, error) {
-	envVar, err := pv.client.GetEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) EnvVarExists(organization, projectName, envVarName string) (bool, error) {
+	envVar, err := pv.client.GetEnvVar(pv.vcsType, organization, projectName, envVarName)
 	if err != nil {
 		return false, err
 	}
@@ -46,11 +44,11 @@ func (pv *ProviderClient) EnvVarExists(projectName, envVarName string) (bool, er
 }
 
 // AddEnvVar create an environment variable with given name and value
-func (pv *ProviderClient) AddEnvVar(projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
-	return pv.client.AddEnvVar(pv.vcsType, pv.organization, projectName, envVarName, envVarValue)
+func (pv *ProviderClient) AddEnvVar(organization, projectName, envVarName, envVarValue string) (*circleciapi.EnvVar, error) {
+	return pv.client.AddEnvVar(pv.vcsType, organization, projectName, envVarName, envVarValue)
 }
 
 // DeleteEnvVar delete the environment variable with given name
-func (pv *ProviderClient) DeleteEnvVar(projectName, envVarName string) error {
-	return pv.client.DeleteEnvVar(pv.vcsType, pv.organization, projectName, envVarName)
+func (pv *ProviderClient) DeleteEnvVar(organization, projectName, envVarName string) error {
+	return pv.client.DeleteEnvVar(pv.vcsType, organization, projectName, envVarName)
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -11,14 +11,29 @@ import (
 var testProvider *schema.Provider
 var testProviders map[string]terraform.ResourceProvider
 
+var resourceOrgTestProvider *schema.Provider
+var resourceOrgTestProviders map[string]terraform.ResourceProvider
+
 func init() {
+	resourceOrgTestProvider = Provider().(*schema.Provider)
+	resourceOrgTestProviders = map[string]terraform.ResourceProvider{
+		"circleci": resourceOrgTestProvider,
+	}
+
 	testProvider = Provider().(*schema.Provider)
+	testProvider.Schema["organization"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("TEST_CIRCLECI_ORGANIZATION", nil),
+		Description: "The CircleCI organization.",
+	}
 	testProviders = map[string]terraform.ResourceProvider{
 		"circleci": testProvider,
 	}
 }
 
 func testPreCheck(t *testing.T) {
+
 	if v := os.Getenv("CIRCLECI_TOKEN"); v == "" {
 		t.Fatal("CIRCLECI_TOKEN must be set for acceptance tests")
 	}
@@ -29,5 +44,9 @@ func testPreCheck(t *testing.T) {
 
 	if v := os.Getenv("CIRCLECI_PROJECT"); v == "" {
 		t.Fatal("CIRCLECI_PROJECT must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v != "" {
+		t.Fatal("For testing purposes do not set CIRCLECI_ORGANIZATION instead set TEST_CIRCLECI_ORGANIZATION for acceptance tests")
 	}
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -49,4 +49,8 @@ func testPreCheck(t *testing.T) {
 	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v != "" {
 		t.Fatal("For testing purposes do not set CIRCLECI_ORGANIZATION instead set TEST_CIRCLECI_ORGANIZATION for acceptance tests")
 	}
+
+	if v := os.Getenv("TEST_CIRCLECI_ORGANIZATION"); v == "" {
+		t.Fatal("TEST_CIRCLECI_ORGANIZATION must be set for acceptance tests")
+	}
 }

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-var testProvider *schema.Provider
-var testProviders map[string]terraform.ResourceProvider
+var providerOrgTestProvider *schema.Provider
+var providerOrgTestProviders map[string]terraform.ResourceProvider
 
 var resourceOrgTestProvider *schema.Provider
 var resourceOrgTestProviders map[string]terraform.ResourceProvider
@@ -20,15 +20,15 @@ func init() {
 		"circleci": resourceOrgTestProvider,
 	}
 
-	testProvider = Provider().(*schema.Provider)
-	testProvider.Schema["organization"] = &schema.Schema{
+	providerOrgTestProvider = Provider().(*schema.Provider)
+	providerOrgTestProvider.Schema["organization"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		DefaultFunc: schema.EnvDefaultFunc("TEST_CIRCLECI_ORGANIZATION", nil),
 		Description: "The CircleCI organization.",
 	}
-	testProviders = map[string]terraform.ResourceProvider{
-		"circleci": testProvider,
+	providerOrgTestProviders = map[string]terraform.ResourceProvider{
+		"circleci": providerOrgTestProvider,
 	}
 }
 

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -27,10 +27,6 @@ func testPreCheck(t *testing.T) {
 		t.Fatal("CIRCLECI_VCS_TYPE must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("CIRCLECI_ORGANIZATION"); v == "" {
-		t.Fatal("CIRCLECI_ORGANIZATION must be set for acceptance tests")
-	}
-
 	if v := os.Getenv("CIRCLECI_PROJECT"); v == "" {
 		t.Fatal("CIRCLECI_PROJECT must be set for acceptance tests")
 	}

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -30,7 +30,7 @@ func resourceCircleCIEnvironmentVariable() *schema.Resource {
 			"organization": {
 				Description: "The CircleCI organization.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 			},
 			"project": {
@@ -83,7 +83,7 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
@@ -109,7 +109,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -130,7 +130,7 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -147,7 +147,7 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
-	organization := d.Get("organization").(string)
+	organization := getOrganization(d)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -157,4 +157,14 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	}
 
 	return bool(envVar.Value != ""), nil
+}
+
+func getOrganization(d *schema.ResourceData) *string {
+	organization, ok := d.GetOk("organization")
+	if ok {
+		org := organization.(string)
+		return &org
+	}
+
+	return nil
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -159,11 +159,11 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	return bool(envVar.Value != ""), nil
 }
 
-func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) *string {
+func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) string {
 	organization, ok := d.GetOk("organization")
 	if ok {
 		org := organization.(string)
-		return &org
+		return org
 	}
 
 	return providerClient.organization

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -83,7 +83,7 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
@@ -109,7 +109,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -130,7 +130,7 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -147,7 +147,7 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
-	organization := getOrganization(d)
+	organization := getOrganization(d, providerClient)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
@@ -159,12 +159,12 @@ func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interfa
 	return bool(envVar.Value != ""), nil
 }
 
-func getOrganization(d *schema.ResourceData) *string {
+func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) *string {
 	organization, ok := d.GetOk("organization")
 	if ok {
 		org := organization.(string)
 		return &org
 	}
 
-	return nil
+	return providerClient.organization
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -103,7 +103,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 	}
 
 	vars := []string{
-		*organization,
+		organization,
 		projectName,
 		envName,
 	}
@@ -191,20 +191,19 @@ func getOrganization(d *schema.ResourceData, providerClient *ProviderClient) str
 }
 
 func getEnvironmentVariableId(d *schema.ResourceData) error {
-	parts := parseEnvironmentVariableId(d.Id())
+	organization, projectName, envName := parseEnvironmentVariableId(d.Id())
 	// Validate that he have values for all the ID segments. This should be at least 3
-	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+	if organization == "" || projectName == "" || envName == "" {
 		return fmt.Errorf("error calculating circle_ci_environment_variable. Please make sure the ID is in the form ORGANIZATION.PROJECTNAME.VARNAME (i.e. foo.bar.my_var)")
 	}
 
-	_ = d.Set("organization", parts[0])
-	_ = d.Set("project", parts[1])
-	_ = d.Set("name", parts[2])
+	_ = d.Set("organization", organization)
+	_ = d.Set("project", projectName)
+	_ = d.Set("name", envName)
 	return nil
 }
 
-func parseEnvironmentVariableId(id string) [3]string {
-	var organization, projectName, envName string
+func parseEnvironmentVariableId(id string) (organization, projectName, envName string) {
 	parts := strings.Split(id, ".")
 
 	if len(parts) >= 3 {
@@ -213,5 +212,5 @@ func parseEnvironmentVariableId(id string) [3]string {
 		envName = parts[len(parts)-1]
 	}
 
-	return [3]string{organization, projectName, envName}
+	return organization, projectName, envName
 }

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -27,6 +27,12 @@ func resourceCircleCIEnvironmentVariable() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"organization": {
+				Description: "The CircleCI organization.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
 			"project": {
 				Description: "The name of the CircleCI project to create the variable in",
 				Type:        schema.TypeString,
@@ -77,11 +83,12 @@ func hashString(str string) string {
 func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
 
-	exists, err := providerClient.EnvVarExists(projectName, envName)
+	exists, err := providerClient.EnvVarExists(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -90,7 +97,7 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 		return fmt.Errorf("environment variable '%s' already exists for project '%s'", envName, projectName)
 	}
 
-	if _, err := providerClient.AddEnvVar(projectName, envName, envValue); err != nil {
+	if _, err := providerClient.AddEnvVar(organization, projectName, envName, envValue); err != nil {
 		return err
 	}
 
@@ -102,10 +109,11 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	envVar, err := providerClient.GetEnvVar(projectName, envName)
+	envVar, err := providerClient.GetEnvVar(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -122,10 +130,11 @@ func resourceCircleCIEnvironmentVariableRead(d *schema.ResourceData, m interface
 func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interface{}) error {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	err := providerClient.DeleteEnvVar(projectName, envName)
+	err := providerClient.DeleteEnvVar(organization, projectName, envName)
 	if err != nil {
 		return err
 	}
@@ -138,10 +147,11 @@ func resourceCircleCIEnvironmentVariableDelete(d *schema.ResourceData, m interfa
 func resourceCircleCIEnvironmentVariableExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	providerClient := m.(*ProviderClient)
 
+	organization := d.Get("organization").(string)
 	projectName := d.Get("project").(string)
 	envName := d.Get("name").(string)
 
-	envVar, err := providerClient.GetEnvVar(projectName, envName)
+	envVar, err := providerClient.GetEnvVar(organization, projectName, envName)
 	if err != nil {
 		return false, err
 	}

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -161,15 +161,6 @@ func resourceCircleCIEnvironmentVariableCreate(d *schema.ResourceData, m interfa
 	envName := d.Get("name").(string)
 	envValue := d.Get("value").(string)
 
-	exists, err := providerClient.EnvVarExists(organization, projectName, envName)
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		return fmt.Errorf("environment variable '%s' already exists for project '%s'", envName, projectName)
-	}
-
 	if _, err := providerClient.AddEnvVar(organization, projectName, envName, envValue); err != nil {
 		return err
 	}

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -197,9 +197,9 @@ func getEnvironmentVariableId(d *schema.ResourceData) error {
 		return fmt.Errorf("error calculating circle_ci_environment_variable. Please make sure the ID is in the form ORGANIZATION.PROJECTNAME.VARNAME (i.e. foo.bar.my_var)")
 	}
 
-	d.Set("organization", parts[0])
-	d.Set("project", parts[1])
-	d.Set("name", parts[2])
+	_ = d.Set("organization", parts[0])
+	_ = d.Set("project", parts[1])
+	_ = d.Set("name", parts[2])
 	return nil
 }
 
@@ -207,10 +207,10 @@ func parseEnvironmentVariableId(id string) [3]string {
 	var organization, projectName, envName string
 	parts := strings.Split(id, ".")
 
-	if len(parts) == 3 {
+	if len(parts) >= 3 {
 		organization = parts[0]
-		projectName = parts[1]
-		envName = parts[2]
+		projectName = strings.Join(parts[1:len(parts)-1], ".")
+		envName = parts[len(parts)-1]
 	}
 
 	return [3]string{organization, projectName, envName}

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -20,9 +20,8 @@ func TestCircleCIEnvironmentVariableOrganizationNotSet(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
-		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
-		IsUnitTest:   true,
+		Providers:  resourceOrgTestProviders,
+		IsUnitTest: true,
 		Steps: []resource.TestStep{
 			{
 				Config:      testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test"),
@@ -67,7 +66,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
-	organization := "ORG_" + acctest.RandString(8)
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 	envName := "TEST_" + acctest.RandString(8)
 
 	resourceName := "circleci_environment_variable." + envName
@@ -76,7 +75,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
+		Providers:    resourceOrgTestProviders,
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,7 +100,6 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
-	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
 
@@ -115,7 +113,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, envValue),
+				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -123,7 +121,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 				),
 			},
 			{
-				Config:      testCircleCIEnvironmentVariableConfigIdentical(organization, project, envName, envValue),
+				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
 			},
 		},
@@ -171,19 +169,17 @@ resource "circleci_environment_variable" "%[2]s" {
 }`, project, name, value, organization)
 }
 
-func testCircleCIEnvironmentVariableConfigIdentical(organization, project, name, value string) string {
+func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  organization = "%[4]s"
   project 	   = "%[1]s"
   name    	   = "%[2]s"
   value   	   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  organization = "%[4]s"
   project 	   = "%[1]s"
   name    	   = "%[2]s"
   value   	   = "%[3]s"
-}`, project, name, value, organization)
+}`, project, name, value)
 }

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -146,10 +146,10 @@ func testCircleCIEnvironmentVariableCheckDestroy(providerClient *ProviderClient,
 
 		organization := rs.Primary.Attributes["organization"]
 		if organization == "" {
-			organization = *providerClient.organization
+			organization = providerClient.organization
 		}
 
-		envVar, err := providerClient.GetEnvVar(&organization, rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
+		envVar, err := providerClient.GetEnvVar(organization, rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
 		if err != nil {
 			return err
 		}

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 
 	resourceName := "circleci_environment_variable." + envName
@@ -26,7 +27,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, "value-for-the-test"),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -34,7 +35,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, "value-for-the-test-again"),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -47,6 +48,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdate(t *testing.T) {
 
 func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := "ORG_" + acctest.RandString(8)
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
 
@@ -60,7 +62,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 		CheckDestroy: testCircleCIEnvironmentVariableCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCircleCIEnvironmentVariableConfig(project, envName, envValue),
+				Config: testCircleCIEnvironmentVariableConfig(organization, project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
@@ -68,7 +70,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 				),
 			},
 			{
-				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
+				Config:      testCircleCIEnvironmentVariableConfigIdentical(organization, project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
 			},
 		},
@@ -83,7 +85,7 @@ func testCircleCIEnvironmentVariableCheckDestroy(s *terraform.State) error {
 			continue
 		}
 
-		envVar, err := providerClient.GetEnvVar(rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
+		envVar, err := providerClient.GetEnvVar(rs.Primary.Attributes["organization"], rs.Primary.Attributes["project"], rs.Primary.Attributes["name"])
 		if err != nil {
 			return err
 		}
@@ -96,26 +98,29 @@ func testCircleCIEnvironmentVariableCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCircleCIEnvironmentVariableConfig(project, name, value string) string {
+func testCircleCIEnvironmentVariableConfig(organization, project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
-}`, project, name, value)
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
+}`, project, name, value, organization)
 }
 
-func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
+func testCircleCIEnvironmentVariableConfigIdentical(organization, project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  project = "%[1]s"
-  name    = "%[2]s"
-  value   = "%[3]s"
-}`, project, name, value)
+  organization = "%[4]s"
+  project 	   = "%[1]s"
+  name    	   = "%[2]s"
+  value   	   = "%[3]s"
+}`, project, name, value, organization)
 }

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -3,6 +3,7 @@ package circleci
 import (
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"regexp"
 	"testing"
@@ -201,6 +202,27 @@ func TestCircleCIEnvironmentVariableImportResourceOrg(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestParseEnvironmentVariableId(t *testing.T) {
+	organization := acctest.RandString(8)
+	envName := acctest.RandString(8)
+	projectNames := []string{
+		"TEST_" + acctest.RandString(8),
+		"TEST-" + acctest.RandString(8),
+		"TEST." + acctest.RandString(8),
+		"TEST_" + acctest.RandString(8) + "." + acctest.RandString(8),
+		"TEST-" + acctest.RandString(8) + "." + acctest.RandString(8),
+		"TEST." + acctest.RandString(8) + "." + acctest.RandString(8),
+	}
+
+	for _, name := range projectNames {
+		expectedId := organization + "." + name + "." + envName
+		actualOrganization, actualProjectName, actualEnvName := parseEnvironmentVariableId(expectedId)
+		assert.Equal(t, organization, actualOrganization)
+		assert.Equal(t, name, actualProjectName)
+		assert.Equal(t, envName, actualEnvName)
+	}
 }
 
 func testCircleCIEnvironmentVariableResourceOrgCheckDestroy(s *terraform.State) error {

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -41,7 +41,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 		PreCheck: func() {
 			testPreCheck(t)
 		},
-		Providers:    testProviders,
+		Providers:    providerOrgTestProviders,
 		CheckDestroy: testCircleCIEnvironmentVariableProviderOrgCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -106,7 +106,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	resourceName := "circleci_environment_variable." + envName
 
 	resource.Test(t, resource.TestCase{
-		Providers: testProviders,
+		Providers: providerOrgTestProviders,
 		PreCheck: func() {
 			testPreCheck(t)
 		},
@@ -134,7 +134,7 @@ func testCircleCIEnvironmentVariableResourceOrgCheckDestroy(s *terraform.State) 
 }
 
 func testCircleCIEnvironmentVariableProviderOrgCheckDestroy(s *terraform.State) error {
-	providerClient := testProvider.Meta().(*ProviderClient)
+	providerClient := providerOrgTestProvider.Meta().(*ProviderClient)
 	return testCircleCIEnvironmentVariableCheckDestroy(providerClient, s)
 }
 

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -165,9 +165,9 @@ func testCircleCIEnvironmentVariableCheckDestroy(providerClient *ProviderClient,
 func testCircleCIEnvironmentVariableConfigProviderOrg(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }`, project, name, value)
 }
 
@@ -184,14 +184,14 @@ resource "circleci_environment_variable" "%[2]s" {
 func testCircleCIEnvironmentVariableConfigIdentical(project, name, value string) string {
 	return fmt.Sprintf(`
 resource "circleci_environment_variable" "%[2]s" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }
 
 resource "circleci_environment_variable" "%[2]s_2" {
-  project 	   = "%[1]s"
-  name    	   = "%[2]s"
-  value   	   = "%[3]s"
+  project = "%[1]s"
+  name    = "%[2]s"
+  value   = "%[3]s"
 }`, project, name, value)
 }

--- a/circleci/resource_circleci_environment_variable_test.go
+++ b/circleci/resource_circleci_environment_variable_test.go
@@ -34,8 +34,8 @@ func TestCircleCIEnvironmentVariableOrganizationNotSet(t *testing.T) {
 func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
 	envName := "TEST_" + acctest.RandString(8)
-
 	resourceName := "circleci_environment_variable." + envName
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -47,6 +47,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
@@ -55,6 +56,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateProviderOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test-again")),
@@ -81,6 +83,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
@@ -89,6 +92,7 @@ func TestCircleCIEnvironmentVariableCreateThenUpdateResourceOrg(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test-again"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test-again")),
@@ -102,6 +106,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 	project := os.Getenv("CIRCLECI_PROJECT")
 	envName := "TEST_" + acctest.RandString(8)
 	envValue := acctest.RandString(8)
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
 
 	resourceName := "circleci_environment_variable." + envName
 
@@ -115,6 +120,7 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 			{
 				Config: testCircleCIEnvironmentVariableConfigProviderOrg(project, envName, envValue),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
 					resource.TestCheckResourceAttr(resourceName, "project", project),
 					resource.TestCheckResourceAttr(resourceName, "name", envName),
 					resource.TestCheckResourceAttr(resourceName, "value", hashString(envValue)),
@@ -123,6 +129,75 @@ func TestCircleCIEnvironmentVariableCreateAlreadyExists(t *testing.T) {
 			{
 				Config:      testCircleCIEnvironmentVariableConfigIdentical(project, envName, envValue),
 				ExpectError: regexp.MustCompile("already exists"),
+			},
+		},
+	})
+}
+
+func TestCircleCIEnvironmentVariableImportProviderOrg(t *testing.T) {
+	project := os.Getenv("CIRCLECI_PROJECT")
+	envName := "TEST_" + acctest.RandString(8)
+	resourceName := "circleci_environment_variable." + envName
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testPreCheck(t)
+		},
+		Providers:    providerOrgTestProviders,
+		CheckDestroy: testCircleCIEnvironmentVariableProviderOrgCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "name", envName),
+					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("circleci_environment_variable.%s", envName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
+			},
+		},
+	})
+}
+
+func TestCircleCIEnvironmentVariableImportResourceOrg(t *testing.T) {
+	project := os.Getenv("CIRCLECI_PROJECT")
+	organization := os.Getenv("TEST_CIRCLECI_ORGANIZATION")
+	envName := "TEST_" + acctest.RandString(8)
+
+	resourceName := "circleci_environment_variable." + envName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testPreCheck(t)
+		},
+		Providers:    resourceOrgTestProviders,
+		CheckDestroy: testCircleCIEnvironmentVariableResourceOrgCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCircleCIEnvironmentVariableConfigResourceOrg(organization, project, envName, "value-for-the-test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s.%s.%s", organization, project, envName)),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "name", envName),
+					resource.TestCheckResourceAttr(resourceName, "value", hashString("value-for-the-test")),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("circleci_environment_variable.%s", envName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/jszwedko/go-circleci v0.2.0
+	github.com/stretchr/testify v1.3.0
 )
 
 replace github.com/jszwedko/go-circleci v0.2.0 => github.com/tgermain/go-circleci v0.0.0-20181207123242-bfc5b3445bba


### PR DESCRIPTION
When using the provider we've come across a number of times whereby importing an existing environment variable in becomes untenable, and we'd rather just override the existing value to set it to a known good state.

It also looks like other providers delegate the existence checking to the API and assume that will return an error if it already exists. I feel like we should probably follow the precedent of other providers in this case

Requires #26 and #27 