### PR TITLE
update CircleCI link to point to build url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CircleCI Terraform provider
 
-[![Build Status](https://circleci.com/gh/mrolla/terraform-provider-circleci.svg?style=shield)](https://circleci.com/gh/mrolla/terraform-provider-circleci.svg?style=shield) [![Go Report Card](https://goreportcard.com/badge/github.com/mrolla/terraform-provider-circleci)](https://goreportcard.com/badge/github.com/mrolla/terraform-provider-circleci)
+[![Build Status](https://circleci.com/gh/mrolla/terraform-provider-circleci.svg?style=shield)](https://circleci.com/gh/mrolla/terraform-provider-circleci/tree/master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mrolla/terraform-provider-circleci)](https://goreportcard.com/badge/github.com/mrolla/terraform-provider-circleci)
 
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)


### PR DESCRIPTION
Hello :slightly_smiling_face: ,

I just wanted to point your build url to where your builds actually happen instead of pointing to the image again. I use CircleCI as well, that is why I know how to construct the url to your build. :slightly_smiling_face: 

Have a great day :grin: