### PR TITLE
`context_environment_variable`: handle context deletion

### DIFF
--- a/circleci/client/context.go
+++ b/circleci/client/context.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/CircleCI-Public/circleci-cli/api"
@@ -22,7 +23,12 @@ func (c *Client) GetContext(id string) (*api.Context, error) {
 
 	status, err := c.rest.DoRequest(req, ctx)
 	if err != nil {
-		if status == 404 {
+		if status == http.StatusNotFound {
+			return nil, ErrContextNotFound
+		}
+
+		// 404 is standard but CircleCI currently returns 403 for GETs to deleted contexts
+		if status == http.StatusForbidden {
 			return nil, ErrContextNotFound
 		}
 

--- a/circleci/client/context_environment.go
+++ b/circleci/client/context_environment.go
@@ -1,6 +1,10 @@
 package client
 
-import "github.com/CircleCI-Public/circleci-cli/api"
+import (
+	"errors"
+
+	"github.com/CircleCI-Public/circleci-cli/api"
+)
 
 // CreateOrUpdateContextEnvironmentVariable creates a new context environment variable
 func (c *Client) CreateOrUpdateContextEnvironmentVariable(ctx, variable, value string) error {
@@ -16,6 +20,14 @@ func (c *Client) ListContextEnvironmentVariables(ctx string) (*[]api.Environment
 // HasContextEnvironmentVariable lists all environment variables for a given context and checks whether the specified variable is defined.
 // If either the context or the variable does not exist, it returns false.
 func (c *Client) HasContextEnvironmentVariable(ctx, variable string) (bool, error) {
+	if _, err := c.GetContext(ctx); err != nil {
+		if errors.Is(err, ErrContextNotFound) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
 	envs, err := c.ListContextEnvironmentVariables(ctx)
 	if err != nil {
 		if isNotFound(err) {


### PR DESCRIPTION
Adds state removal logic for context environment variables. When the parent context is no longer accessible, the state for a variable should be removed and not refreshed.

This was already done for contexts themselves, but not their variables. Additionally, The API has either changed or the original 404 detection was never working. In reality, when performing a `GET` request to a context you owned but just deleted, you get a 403 response. Same for any random context ID. Adding `StatusForbidden` ensures that logic works.

An acceptance test triggers the deletion of the context outside of Terraform and ensures that refreshes continue to work. If the fix is removed, this test fails:

```
=== RUN   TestAccCircleCIContextEnvironmentVariable_deleted_context
    testing.go:705: Step 0 error: errors during follow-up refresh:

        Error: You don't have permission to view that context.


    testing.go:766: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: You don't have permission to view that context.

        State: <nil>
```

Full output:

```
make testacc TESTARGS='-run TestAccCircleCIContextEnvironmentVariable'
TF_ACC=1 go test ./... -v -run TestAccCircleCIContextEnvironmentVariable -timeout 120m
?   	github.com/mrolla/terraform-provider-circleci	[no test files]
=== RUN   TestAccCircleCIContextEnvironmentVariable_basic
--- PASS: TestAccCircleCIContextEnvironmentVariable_basic (2.68s)
=== RUN   TestAccCircleCIContextEnvironmentVariable_update
--- PASS: TestAccCircleCIContextEnvironmentVariable_update (3.56s)
=== RUN   TestAccCircleCIContextEnvironmentVariable_deleted_context
--- PASS: TestAccCircleCIContextEnvironmentVariable_deleted_context (3.65s)
=== RUN   TestAccCircleCIContextEnvironmentVariable_import
--- PASS: TestAccCircleCIContextEnvironmentVariable_import (2.53s)
=== RUN   TestAccCircleCIContextEnvironmentVariable_import_name
--- PASS: TestAccCircleCIContextEnvironmentVariable_import_name (2.44s)
PASS
ok  	github.com/mrolla/terraform-provider-circleci/circleci	15.190s
?   	github.com/mrolla/terraform-provider-circleci/circleci/client	[no test files]
?   	github.com/mrolla/terraform-provider-circleci/circleci/client/rest	[no test files]
```

Closes #66