### PR TITLE
Feature: Retry errors from CCI 3 times in order to sidestep retryable errors

### DIFF
--- a/circleci/client/rest/client.go
+++ b/circleci/client/rest/client.go
@@ -60,10 +60,25 @@ func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req
 }
 
 func (c *Client) DoRequest(req *http.Request, resp interface{}) (statusCode int, err error) {
-	httpResp, err := c.client.Do(req)
+	var (
+		err      error
+        httpResp *http.Response
+        retries  int = 3
+    )
+	for retries > 0 {
+        httpResp, err = c.client.Do(req)
+
+        if err != nil {
+            retries -= 1
+        } else {
+            break
+        }
+    }
+
 	if err != nil {
 		return 0, err
 	}
+
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode >= 300 {


### PR DESCRIPTION
# Motivation

https://github.com/mrolla/terraform-provider-circleci/issues/70

^ seeing the same errors as above...when running this...from inside CCI. This is the simplest solution I could whip up. I'm not a Go native developer, but figured this would be a good enough first pass! Happy to try and make changes as suggested etc.

Thanks for making this awesome provider! Our ops team is really happy with it 😄 

## Suggested Musical Pairing

https://soundcloud.com/madonna/hung-up-album-version