### PR TITLE
increase timeout for rest client to 30 seconds

### DIFF
--- a/circleci/client/rest/client.go
+++ b/circleci/client/rest/client.go
@@ -28,7 +28,7 @@ func New(host, endpoint, circleToken string) *Client {
 		baseURL:     u.ResolveReference(&url.URL{Path: endpoint}),
 		circleToken: circleToken,
 		client: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
We are regularly seeing timeouts when reading contexts from the API

```
Error: Get "https://circleci.com/api/v2/context/<context_id>": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Tracing the code through, it seems that this rest client is used for GetContext so updating here should be the solution to this specific issue.